### PR TITLE
Cleanup and corrected pool-id handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Very basic script. Haven't added any support for tls or auth. It loops through the subnets and the shared subnets to list the pool usage/total allocated.
 
-The version of Kea (2.6.2) that was tested against appears to combine the pools into a single pool for the purpose of statistics. The script checks to see if other pool indexes exist just in case it changes.
+If you give a pool-id to pools, it will show them individually. Pools without ids get combined as pool-id 0 and are displayed combined.
 
 Example output:
 
@@ -27,6 +27,7 @@ mgmt-networks
                     10.0.16.0/20                 0      3838
                     Total                        0      3838
 test-networks
-                    192.168.88.0/24              2        11
+                    192.168.88.0/24-1            1         4
+                    192.168.88.0/24-2            1         7
                     Total                        2        11
 ```

--- a/kea-pool-status
+++ b/kea-pool-status
@@ -7,6 +7,32 @@ url = 'http://127.0.0.1:8000/'
 config = {'service': [ 'dhcp4' ], 'command': 'config-get', 'arguments': ''}
 data = {'service': [ 'dhcp4' ], 'command': 'statistic-get-all', 'arguments': ''}
 
+def process_subnets(subnets,totals=False):
+  allused=0
+  alltotal=0
+  for subnet in subnets:
+    if 'pools' in subnet:
+      defaultprinted = False
+      for pool in subnet['pools']:
+        if 'pool-id' in pool:
+          pool_id=pool['pool-id']
+        else:
+          pool_id=0
+        if pool_id == 0:
+          network=subnet['subnet']
+        else:
+          network=f"{subnet['subnet']}-{pool_id}"
+        subnetstr=f"subnet[{str(subnet['id'])}].pool[{str(pool_id)}]"
+        if subnetstr + '.assigned-addresses' in data[0]['arguments']:
+          if pool_id != 0 or not defaultprinted:
+            allused += data[0]['arguments'][subnetstr + '.assigned-addresses'][0][0]
+            alltotal += data[0]['arguments'][subnetstr + '.total-addresses'][0][0]
+            print(f"{'':20}{network:20}{data[0]['arguments'][subnetstr + '.assigned-addresses'][0][0]:>10}{data[0]['arguments'][subnetstr + '.total-addresses'][0][0]:>10}")
+          if pool_id == 0:
+            defaultprinted = True
+  print(f"{'':20}{'Total':20}{allused:>10}{alltotal:>10}")
+
+
 try:
   response = requests.post(url, json=config)
 
@@ -36,36 +62,10 @@ print('-' * 60)
 
 if 'subnet4' in config[0]['arguments']['Dhcp4']:
   print(f"{'Unshared Subnets':20}")
-  for subnet in config[0]['arguments']['Dhcp4']['subnet4']:
-    if 'pools' in subnet:
-      for idx, pool in enumerate(subnet['pools']):
-        if idx == 0:
-          network=subnet['subnet']
-        else:
-          network=f"{subnet['subnet']}-{idx+1}"
-        subnetstr=f"subnet[{str(subnet['id'])}].pool[{str(idx)}]"
-        if subnetstr + '.assigned-addresses' in data[0]['arguments']:
-          print(f"{'':20}{network:20}{data[0]['arguments'][subnetstr + '.assigned-addresses'][0][0]:>10}{data[0]['arguments'][subnetstr + '.total-addresses'][0][0]:>10}")
+  process_subnets(config[0]['arguments']['Dhcp4']['subnet4'])
 
 if 'shared-networks' in config[0]['arguments']['Dhcp4']:
   for sharednet in config[0]['arguments']['Dhcp4']['shared-networks']:
     print(f"{sharednet['name']:20}")
-    allused=0
-    alltotal=0
     if 'subnet4' in sharednet:
-      for subnet in sharednet['subnet4']:
-        if 'pools' in subnet:
-          for idx, pool in enumerate(subnet['pools']):
-            if idx == 0:
-              network=subnet['subnet']
-            else:
-              network=f"{subnet['subnet']}-{idx+1}"
-            subnetstr=f"subnet[{str(subnet['id'])}].pool[{str(idx)}]"
-            if subnetstr + '.assigned-addresses' in data[0]['arguments']:
-              allused += data[0]['arguments'][subnetstr + '.assigned-addresses'][0][0]
-              alltotal += data[0]['arguments'][subnetstr + '.total-addresses'][0][0]
-              print(f"{'':20}{network:20}{data[0]['arguments'][subnetstr + '.assigned-addresses'][0][0]:>10}{data[0]['arguments'][subnetstr + '.total-addresses'][0][0]:>10}")
-    print(f"{'':20}{'Total':20}{allused:>10}{alltotal:>10}")
-
-
-
+      process_subnets(sharednet['subnet4'],True)


### PR DESCRIPTION
Documentation is limited on pool-id. Found it mentioned in the API. I was trying to use the index which is not how Kea processes ids. We should handle both specified and unspecified correctly now.

Also cleaned up the code a bit. Too much duplication.